### PR TITLE
Update weirdAAL.py

### DIFF
--- a/weirdAAL.py
+++ b/weirdAAL.py
@@ -15,7 +15,10 @@ from modules import *
 import sys
 import builtins
 import re
-from tabulate import tabulate
+#from tabulate import tabulate
+from collections.abc import Iterable
+from collections import namedtuple
+
 import textwrap
 
 # Let a user set .aws/credentials or another file as the credentials source


### PR DESCRIPTION
Fixed: ImportError: cannot import name 'Iterable' from 'collections' for python3.11 version

The error occurs because the `weirdAAL.py` script attempts to import the Iterable class from the collections module, which does not include this class in Python 3.11. In Python 3.11, the Iterable class is included in the collections.abc module instead.